### PR TITLE
Add CI-failing dynamic assertions

### DIFF
--- a/src/Assertions.bsv
+++ b/src/Assertions.bsv
@@ -7,7 +7,7 @@ package Assertions;
         provisos (Bits#(t, sz_t), Eq#(t), FShow#(t));
         action
             if(expected != actual) begin
-                printColorTimed(RED, $format("Assertion failed: ") + additional_info + $format("\nExpected: ") + fshow(expected) + $format(", got ") + fshow(actual));
+                printColorTimed(RED, $format("ERROR: Assertion failed: ") + additional_info + $format("\nExpected: ") + fshow(expected) + $format(", got ") + fshow(actual));
                 bad_exit(-1);
             end
         endaction
@@ -16,7 +16,7 @@ package Assertions;
     function Action assertTrue(Bool exp, Fmt additional_info);
         action
             if(!exp) begin
-                printColorTimed(RED, $format("Assertion failed: ") + additional_info);
+                printColorTimed(RED, $format("ERROR: Assertion failed: ") + additional_info);
                 bad_exit(-1);
             end
         endaction
@@ -25,7 +25,7 @@ package Assertions;
     function Action assertFalse(Bool exp, Fmt additional_info);
         action
             if(exp) begin
-                printColorTimed(RED, $format("Assertion failed: ") + additional_info);
+                printColorTimed(RED, $format("ERROR: Assertion failed: ") + additional_info);
                 bad_exit(-1);
             end
         endaction

--- a/src/Assertions.bsv
+++ b/src/Assertions.bsv
@@ -1,0 +1,33 @@
+package Assertions;
+    import BlueLibTests::*;
+
+    import "BDPI" function Action bad_exit(Int#(32) code); // Wrapper for C exit function to make assertions CI-capable
+
+    function Action assertEquals(t expected, t actual, Fmt additional_info)
+        provisos (Bits#(t, sz_t), Eq#(t), FShow#(t));
+        action
+            if(expected != actual) begin
+                printColorTimed(RED, $format("Assertion failed: ") + additional_info + $format("\nExpected: ") + fshow(expected) + $format(", got ") + fshow(actual));
+                bad_exit(-1);
+            end
+        endaction
+    endfunction
+
+    function Action assertTrue(Bool exp, Fmt additional_info);
+        action
+            if(!exp) begin
+                printColorTimed(RED, $format("Assertion failed: ") + additional_info);
+                bad_exit(-1);
+            end
+        endaction
+    endfunction
+
+    function Action assertFalse(Bool exp, Fmt additional_info);
+        action
+            if(exp) begin
+                printColorTimed(RED, $format("Assertion failed: ") + additional_info);
+                bad_exit(-1);
+            end
+        endaction
+    endfunction
+endpackage : Assertions

--- a/src/BDPI/bad_exit.c
+++ b/src/BDPI/bad_exit.c
@@ -1,0 +1,6 @@
+#include <stdlib.h>
+
+// This function is imported in the Assertions package, so assertion fails can fail the CI.
+void bad_exit(unsigned int code) {
+    exit((int) code);
+}


### PR DESCRIPTION
# Summary
This pull request provides dynamic assertions for the common checks for equality, some true expression or some false expression. These assertions provide two main advantages over the ones already provided in BSV:

1. The second parameter is of type ``Fmt`` which allows the error message to be constructed at simulation time, not like the ``dynamicAssert`` which takes ``String`` as second parameter (see also [this issue at the BSC repository](https://github.com/B-Lang-org/bsc/issues/356)).
2. By providing a wrapper to C's ``exit`` we can use these assertions in tests which fail CI-pipelines in a more clean way without having to ``grep`` for specific error messages.

Another IMO nice thing is that the values in ``assertEquals`` have to be in the ``FShow`` typeclass, so we can get meaningful "expected foo, got bar" messages, e.g. when comparing structs.

# Usage Example
* Equality: ``assertEquals(someValue, someOtherValue, $format("Oops, something went wrong");``
* True-check: ``assertTrue(False, $format("Something's wrong here"));``
* False-check: ``assertFalse(True, $format("Something else is wrong here"));``

## More elaborate example:
```
package AssertionTest;
    import Assertions::*;

    typedef struct {
        int a;
        int b;
    } Foo deriving(Bits, Eq, FShow);

    module mkAssertionTest(Empty);
        rule fail;
            Foo x = Foo {a: 42, b: 1337};
            Foo y = Foo {a: 43, b: 1337};
            assertEquals(x, y, $format("Oh no"));
        endrule
    endmodule : mkAssertionTest

endpackage : AssertionTest
```

In a terminal (assuming ``AssertionTest.bsv`` resides in ``BlueLib/src/``):
```
bsc -u -sim -g mkAssertionTest AssertionTest.bsv
bsc -sim -e mkAssertionTest -o assertionTest BDPI/bad_exit.c
./assertionTest
```
Results in the following simulation output (in red color):
```
(0) Assertion failed: Oh no
Expected: Foo { a:          42, b:        1337 }, got Foo { a:          43, b:        1337 }
```