### PR TITLE
Ensure assertions get linked when using BSVTools

### DIFF
--- a/BlueLib.mk
+++ b/BlueLib.mk
@@ -2,5 +2,6 @@ MAKEPATH := $(dir $(lastword $(MAKEFILE_LIST)))
 MODULENAME := BlueLib
 MODULEPATH := $(MAKEPATH)src
 EXTRA_BSV_LIBS += $(MODULEPATH)
+C_FILES += $(wildcard $(MODULEPATH)/BDPI/*.c)
 
 $(info Adding $(MODULENAME) from $(MODULEPATH))

--- a/BlueLib.mk
+++ b/BlueLib.mk
@@ -2,6 +2,10 @@ MAKEPATH := $(dir $(lastword $(MAKEFILE_LIST)))
 MODULENAME := BlueLib
 MODULEPATH := $(MAKEPATH)src
 EXTRA_BSV_LIBS += $(MODULEPATH)
-C_FILES += $(wildcard $(MODULEPATH)/BDPI/*.c)
 
 $(info Adding $(MODULENAME) from $(MODULEPATH))
+ifeq ($(wildcard $(MODULEPATH)/BDPI/),)
+$(warning ./src/BDPI/ folder not found. BlueLib packages requiring C functions may not link successfully.)
+else
+C_FILES += $(wildcard $(MODULEPATH)/BDPI/*.c)
+endif


### PR DESCRIPTION
This PR essentially exposes the ``bad_exit.c`` file required by the ``Assertions`` package to the BSVTools Makefile. 
To be precise, any C files put into ``BlueLib/src/BDPI/`` will be exposed to BSVTools.

Without this PR you have to manually provide the ``C_FILES`` variable when invoking a BSVTools-based ``make`` when using the new assertions.