### PR TITLE
Add .gitignore file for C objects from BDPI folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore C objects after compilation of C code
+src/BDPI/*.o


### PR DESCRIPTION
## What this MR do?

Creates a `.gitignore` file to ignore C objects files after using it in a Bluespec simulation. 

PS: This file is created during the command `make sim` from [`rules.mk`](https://github.com/esa-tu-darmstadt/BSVTools/blob/master/scripts/rules.mk), but cannot be clean with the `make clean` command afterwards.