### PR TITLE
Add Logging file to increase/decrease debug messaging from Makefile

### DIFF
--- a/src/Logging.bsv
+++ b/src/Logging.bsv
@@ -7,11 +7,6 @@ import BuildVector :: *;
 import BlueLibTests :: *;
 import Assertions :: *;
 
-`ifdef FLAG_LOG_TYPES
-typedef `FLAG_LOG_TYPES         FLAG_LOG_TYPES;
-`else 
-typedef "L_WARNING, L_ERROR"    FLAG_LOG_TYPES;
-`endif
 
 typedef enum {
     L_WARNING,
@@ -23,7 +18,7 @@ typedef enum {
 } LoggingLevel deriving (Bits, Eq, FShow);
 
 Bool verbose = False;
-typedef 13 N_LOG_TYPES;
+typedef 6 N_LOG_TYPES;
 
 // Returns a one-hot-encoded LoggingLevel Bit vector
 function Bit#(N_LOG_TYPES) oneHotLog(LoggingLevel level);
@@ -32,8 +27,11 @@ endfunction
 
 function Action debug(LoggingLevel log, Fmt message);
     action
-        // Getting a vector from macros
-        let v_log_config = vec(FLAG_LOG_TYPES);
+        `ifdef FLAG_LOG_TYPES
+        let v_log_config = vec(`FLAG_LOG_TYPES);
+        `else 
+        let v_log_config = vec(L_WARNING, L_ERROR);
+        `endif
         let log_config_1hot = map(oneHotLog, v_log_config);
         // Bit vector encoding the state of log config
         Bit#(N_LOG_TYPES) log_config = fold(\| , log_config_1hot);
@@ -51,11 +49,9 @@ function Action debug(LoggingLevel log, Fmt message);
             else
                 color = BLUE;
             
-            if (log == L_TB_NORMAL || log == L_TB_BLUE || log == L_TB_YELLOW || log == L_TB_GREEN)
-                printColor(color, fshow(message));
-            else if (log != L_ERROR)
+            if (log != L_ERROR)
                 printColor(color, fshow(log) + $format(": ") + fshow(message));
-            else if (log == L_ERROR)
+            else (log == L_ERROR)
                 assertTrue(False, fshow(message));
         end
     endaction

--- a/src/Logging.bsv
+++ b/src/Logging.bsv
@@ -1,0 +1,64 @@
+package Logging;
+
+import OInt :: *;
+import Vector :: *;
+import BuildVector :: *;
+
+import BlueLibTests :: *;
+import Assertions :: *;
+
+`ifdef FLAG_LOG_TYPES
+typedef `FLAG_LOG_TYPES         FLAG_LOG_TYPES;
+`else 
+typedef "L_WARNING, L_ERROR"    FLAG_LOG_TYPES;
+`endif
+
+typedef enum {
+    L_WARNING,
+    L_ERROR,
+    L_TB_NORMAL,
+    L_TB_BLUE,
+    L_TB_YELLOW,
+    L_TB_GREEN
+} LoggingLevel deriving (Bits, Eq, FShow);
+
+Bool verbose = False;
+typedef 13 N_LOG_TYPES;
+
+// Returns a one-hot-encoded LoggingLevel Bit vector
+function Bit#(N_LOG_TYPES) oneHotLog(LoggingLevel level);
+    return pack(toOInt(pack(level))); 
+endfunction
+
+function Action debug(LoggingLevel log, Fmt message);
+    action
+        // Getting a vector from macros
+        let v_log_config = vec(FLAG_LOG_TYPES);
+        let log_config_1hot = map(oneHotLog, v_log_config);
+        // Bit vector encoding the state of log config
+        Bit#(N_LOG_TYPES) log_config = fold(\| , log_config_1hot);
+
+        if( (unpack(pack(toOInt(pack(log)))) & log_config) > 0 || verbose) begin
+            DisplayColors color = ?;
+            if (log == L_WARNING || log == L_TB_YELLOW)
+                color = YELLOW;
+            else if (log == L_ERROR)
+                color = RED;
+            else if (log == L_TB_NORMAL)
+                color = NORMAL;
+            else if (log == L_TB_GREEN)
+                color = GREEN;
+            else
+                color = BLUE;
+            
+            if (log == L_TB_NORMAL || log == L_TB_BLUE || log == L_TB_YELLOW || log == L_TB_GREEN)
+                printColor(color, fshow(message));
+            else if (log != L_ERROR)
+                printColor(color, fshow(log) + $format(": ") + fshow(message));
+            else if (log == L_ERROR)
+                assertTrue(False, fshow(message));
+        end
+    endaction
+endfunction
+
+endpackage

--- a/src/Logging.bsv
+++ b/src/Logging.bsv
@@ -51,7 +51,7 @@ function Action debug(LoggingLevel log, Fmt message);
             
             if (log != L_ERROR)
                 printColor(color, fshow(log) + $format(": ") + fshow(message));
-            else (log == L_ERROR)
+            else
                 assertTrue(False, fshow(message));
         end
     endaction


### PR DESCRIPTION
## What does this PR do? 

This PR creates the package `Logging`. This package includes the function `debug`. This function is able to print in console using the `printColor` function of the package `BlueLibTests` with the difference that this package uses the enum `LoggingLevel` to increase or decrease the debug messaging after compilation. This is possible from the Makefile sending the flag `FLAG_LOG_TYPES`.

I created a new package for this implementation but I think it could also be part of the `BlueLibTests` as enhancement. 

### Why?

The idea of having different colors for debugging purposes is really good. However, for larger projects the amount of prints increase a lot with the time. Using the function `debug` and selecting one of the five possibilities of Levels, the user could increase or reduce the verbose by changing a flag without deleting debugging messages that could be useful later _and/or_ without the need to comment them (as I used to do before).

This approach brings a lot of productivity in addition, if the user changes the enum `LoggingLevel` as necessity. Right now the enum looks like this: 

```bsv
typedef enum {
    L_WARNING,
    L_ERROR,
    L_TB_NORMAL,
    L_TB_BLUE,
    L_TB_YELLOW,
    L_TB_GREEN
} LoggingLevel deriving (Bits, Eq, FShow);
``` 

However, I created a custom version for my project with different levels that allow me to debug my code by modules, which is really helpful. Ex: 

```bsv
typedef enum {
    L_WARNING,
    L_ERROR,
    L_TB_NORMAL,
    L_TB_BLUE,
    L_TB_YELLOW,
    L_TB_GREEN,
    L_CACHE_MEMORY,
    L_CACHE_CONTROL,
    L_CACHE_LEVEL_RD,
    L_CACHE_LEVEL_WR,
    L_CORE_TB,
    L_MEM_TB,
    L_MEM_DELAY_TB
} LoggingLevel deriving (Bits, Eq, FShow);
```

In order to work as expected it is necessary to change the typedef `N_LOG_TYPES` every time that a Logging Level is added. This however is a very small price to pay for the versatility that this approach brings. I did not found anything useful in the BSV documentation to make this process more friendly and out-of-the-box ready to use.

## Summary of Changes

- Add necessary logic to the package `Logging`
- Add a wrap of `ifdef` to avoid errors in compiling if a flag is not present but the Logging package is included

## How to use

Using [BSVTools](https://github.com/esa-tu-darmstadt/BSVTools), I created a project and update the flag `EXTRA_FLAGS` to add the next option: 

```makefile
ifdef FLAG_LOG_TYPES
EXTRA_FLAGS+=-D FLAG_LOG_TYPES="$(FLAG_LOG_TYPES)"
endif
```

After that if I use the `debug` function with a specific type of debugging that **IT IS** include in the flag the message is shown, otherwise is ignored. Ex: 

```bsv
module [Module] mkTestsMainTest(TestHandler);

        HelloWorld dut <- mkHelloWorld();

        Stmt s = {
            seq
                debug(L_TB_GREEN, $format("Hello World from the testbench."));
            endseq
        };
        FSM testFSM <- mkFSM(s);

        method Action go();
            testFSM.start();
        endmethod

        method Bool done();
            return testFSM.done();
        endmethod
    endmodule
```
Two different outputs changing just the flag: 

```bash
$ make clean_all && make FLAG_LOG_TYPES="L_ERROR, L_WARNING"
# Expected output
...
Simulating build/out
Hello World!
Hello World!
Hello World!
Hello World!
Hello World!
Hello World!
Hello World!
```

```bash
$ make clean_all && make FLAG_LOG_TYPES="L_ERROR, L_WARNING, L_TB_GREEN"
# Expected output
...
Simulating build/out
Hello World!
Hello World!
Hello World!
Hello World!
Hello World!
L_TB_GREEN: Hello World from the testbench.
Hello World!
Hello World!
```