### PR TITLE
Logging: add option to remove all logging via define

### DIFF
--- a/BlueLogging.mk
+++ b/BlueLogging.mk
@@ -1,3 +1,7 @@
 ifneq ($(LOG),)
 $(foreach X,$(LOG),$(eval RUN_FLAGS+=+LOG_$X))
 endif
+
+ifneq ($(NOLOG),)
+	EXTRA_FLAGS+=-D NOLOG=1
+endif

--- a/BlueLogging.mk
+++ b/BlueLogging.mk
@@ -5,3 +5,5 @@ endif
 ifneq ($(NOLOG),)
 	EXTRA_FLAGS+=-D NOLOG=1
 endif
+
+REBUILD_LIBRARIES+=Logging

--- a/Logging.md
+++ b/Logging.md
@@ -39,6 +39,11 @@ Example:
 make LOG="GLOBAL=WARN MyPackage=INFO myModule=DEBUG"
 ```
 
+## Disable
+
+Logging can be completely disabled via `make NOLOG=1`, this will remove all Logging-related stuff from the generated verilog.
+This is recommended when building for hardware, as otherwise the output of the Synthesis tool will be cluttered with messages.
+
 ## Alternative
 
 With this alternative approach it is possible to explicitly specify the string being used to determine whether a log message should be displayed (the "log unit").

--- a/src/Logging.bsv
+++ b/src/Logging.bsv
@@ -8,7 +8,9 @@ endinterface
 
 module mkLogger#(String unit)(Logger);
 	method Action log(LogLevel level, Fmt txt);
-		sendMessage(unit, unit, level, txt);
+		`ifndef NOLOG
+			sendMessage(unit, unit, level, txt);
+		`endif
 	endmethod
 endmodule
 

--- a/src/Logging.bsv
+++ b/src/Logging.bsv
@@ -41,8 +41,10 @@ endfunction
 
 function Action sendMessage(String moduleName, String packageName, LogLevel level, Fmt text);
 	action
-		let test <- checkLogging(moduleName, packageName, level);
-		if (test) printColorTimed(getColor(level), $format("[", fshow(level), fshow("]{"), moduleName, fshow("} "), fshow(text)));
+		`ifndef NOLOG
+			let test <- checkLogging(moduleName, packageName, level);
+			if (test) printColorTimed(getColor(level), $format("[", fshow(level), fshow("]{"), moduleName, fshow("} "), fshow(text)));
+		`endif
 	endaction
 endfunction
 


### PR DESCRIPTION
This PR adds the option to remove all logging via:
`make NOLOG=1`.

This is useful when building for hardware (otherwise the logging of the Synthesis tool will be cluttered with messages about removed Logging-related stuff).

The PR also registers the Logging library for automatic rebuild on changed defines (requires https://github.com/esa-tu-darmstadt/BSVTools/pull/25)