### PR TITLE
Add cstdint inlcude

### DIFF
--- a/src/BDPI/random.cpp
+++ b/src/BDPI/random.cpp
@@ -2,6 +2,7 @@
 #include <functional> //for std::hash
 #include <string>
 #include <iostream>
+#include <cstdint>
 
 class RandomGen {
 public:


### PR DESCRIPTION
One of my projects failed to compile for simulation due to a missing declaration of the `uint64_t`  type in the changed source file. Including `cstdint` fixed it for me.